### PR TITLE
Updated to v0.2.0 of `jupyterlab-blockly` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/application": "^3.1.0",
-        "jupyterlab-blockly": "^0.1.1"
+        "jupyterlab-blockly": "^0.2.0"
       },
       "devDependencies": {
         "@jupyterlab/builder": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@jupyterlab/application": "^3.4",
     "blockly": "^7.20211209.2",
-    "jupyterlab-blockly": "^0.1.1",
+    "jupyterlab-blockly": "^0.2.0",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0"
   },
@@ -87,17 +87,7 @@
   },
   "jupyterlab": {
     "extension": true,
-    "outputDir": "jupyterlab_lego_boost/labextension",
-    "sharedPackages": {
-      "jupyterlab-blockly": { 
-        "bundled": false, 
-        "singleton": true 
-      }, 
-      "blockly": { 
-        "bundled": false, 
-        "singleton": true 
-      } 
-    }
+    "outputDir": "jupyterlab_lego_boost/labextension"
   },
   "jupyter-releaser": {
     "hooks": {

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup_args = dict(
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.7",
-    install_requires=['jupyterlab-blockly>=0.1.1,<0.2'],
+    install_requires=['jupyterlab-blockly>=0.2.0,<0.3'],
     extras_require={
         'env': ['bleak', 'pylgbst']
     },

--- a/src/lego_boost_python_generators_and_blocks.js
+++ b/src/lego_boost_python_generators_and_blocks.js
@@ -218,11 +218,7 @@ from pylgbst import get_connection_bleak
 `;
 
 BlocklyPy['lego_boost_move_motor_a_timed'] = function (block) {
-  var value_time = BlocklyPy.valueToCode(
-    block,
-    'TIME',
-    BlocklyPy.ORDER_ATOMIC
-  );
+  var value_time = BlocklyPy.valueToCode(block, 'TIME', BlocklyPy.ORDER_ATOMIC);
 
   var value_speed = BlocklyPy.valueToCode(
     block,
@@ -239,11 +235,7 @@ import time
 `;
 
 BlocklyPy['lego_boost_move_motor_b_timed'] = function (block) {
-  var value_time = BlocklyPy.valueToCode(
-    block,
-    'TIME',
-    BlocklyPy.ORDER_ATOMIC
-  );
+  var value_time = BlocklyPy.valueToCode(block, 'TIME', BlocklyPy.ORDER_ATOMIC);
 
   var value_speed = BlocklyPy.valueToCode(
     block,
@@ -294,11 +286,7 @@ BlocklyPy['lego_boost_move_motor_b_angled'] = function (block) {
 };
 
 BlocklyPy['lego_boost_move_motor_ab_timed'] = function (block) {
-  var value_time = BlocklyPy.valueToCode(
-    block,
-    'TIME',
-    BlocklyPy.ORDER_ATOMIC
-  );
+  var value_time = BlocklyPy.valueToCode(block, 'TIME', BlocklyPy.ORDER_ATOMIC);
 
   var value_speed_a = BlocklyPy.valueToCode(
     block,

--- a/src/lego_boost_python_generators_and_blocks.js
+++ b/src/lego_boost_python_generators_and_blocks.js
@@ -198,11 +198,11 @@ Blockly.Blocks['lego_boost_sleep'] = {
  * Generators
  */
 
-Blockly.Python['lego_boost_connect'] = function (block) {
-  var value_bluetooth_address = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_connect'] = function (block) {
+  var value_bluetooth_address = BlocklyPy.valueToCode(
     block,
     'BLUETOOTH_ADDRESS',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code =
@@ -217,17 +217,17 @@ from pylgbst.hub import MoveHub
 from pylgbst import get_connection_bleak
 `;
 
-Blockly.Python['lego_boost_move_motor_a_timed'] = function (block) {
-  var value_time = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_move_motor_a_timed'] = function (block) {
+  var value_time = BlocklyPy.valueToCode(
     block,
     'TIME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed = Blockly.Python.valueToCode(
+  var value_speed = BlocklyPy.valueToCode(
     block,
     'SPEED',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code = 'hub.motor_A.timed(' + value_time + ', ' + value_speed + ')\n';
@@ -238,17 +238,17 @@ Blockly.Blocks['lego_boost_move_motor_a_timed'].toplevel_init = `
 import time
 `;
 
-Blockly.Python['lego_boost_move_motor_b_timed'] = function (block) {
-  var value_time = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_move_motor_b_timed'] = function (block) {
+  var value_time = BlocklyPy.valueToCode(
     block,
     'TIME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed = Blockly.Python.valueToCode(
+  var value_speed = BlocklyPy.valueToCode(
     block,
     'SPEED',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code = 'hub.motor_B.timed(' + value_time + ', ' + value_speed + ')\n';
@@ -259,57 +259,57 @@ Blockly.Blocks['lego_boost_move_motor_b_timed'].toplevel_init = `
 import time
 `;
 
-Blockly.Python['lego_boost_move_motor_a_angled'] = function (block) {
-  var value_angle = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_move_motor_a_angled'] = function (block) {
+  var value_angle = BlocklyPy.valueToCode(
     block,
     'ANGLE',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed = Blockly.Python.valueToCode(
+  var value_speed = BlocklyPy.valueToCode(
     block,
     'SPEED',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code = 'hub.motor_A.angled(' + value_angle + ', ' + value_speed + ')\n';
   return code;
 };
 
-Blockly.Python['lego_boost_move_motor_b_angled'] = function (block) {
-  var value_angle = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_move_motor_b_angled'] = function (block) {
+  var value_angle = BlocklyPy.valueToCode(
     block,
     'ANGLE',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed = Blockly.Python.valueToCode(
+  var value_speed = BlocklyPy.valueToCode(
     block,
     'SPEED',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code = 'hub.motor_B.angled(' + value_angle + ', ' + value_speed + ')\n';
   return code;
 };
 
-Blockly.Python['lego_boost_move_motor_ab_timed'] = function (block) {
-  var value_time = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_move_motor_ab_timed'] = function (block) {
+  var value_time = BlocklyPy.valueToCode(
     block,
     'TIME',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed_a = Blockly.Python.valueToCode(
+  var value_speed_a = BlocklyPy.valueToCode(
     block,
     'SPEED_A',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed_b = Blockly.Python.valueToCode(
+  var value_speed_b = BlocklyPy.valueToCode(
     block,
     'SPEED_B',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code =
@@ -327,23 +327,23 @@ Blockly.Blocks['lego_boost_move_motor_ab_timed'].toplevel_init = `
 import time
 `;
 
-Blockly.Python['lego_boost_move_motor_ab_angled'] = function (block) {
-  var value_angle = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_move_motor_ab_angled'] = function (block) {
+  var value_angle = BlocklyPy.valueToCode(
     block,
     'ANGLE',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed_a = Blockly.Python.valueToCode(
+  var value_speed_a = BlocklyPy.valueToCode(
     block,
     'SPEED_A',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
-  var value_speed_b = Blockly.Python.valueToCode(
+  var value_speed_b = BlocklyPy.valueToCode(
     block,
     'SPEED_B',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code =
@@ -356,35 +356,36 @@ Blockly.Python['lego_boost_move_motor_ab_angled'] = function (block) {
   return code;
 };
 
-Blockly.Python['lego_boost_start_speed'] = function (block) {
-  var value_speed = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_start_speed'] = function (block) {
+  var value_speed = BlocklyPy.valueToCode(
     block,
     'SPEED',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code = 'hub.motor_external.start_speed(' + value_speed + ')\n';
   return code;
 };
 
-Blockly.Python['lego_boost_stop_motors'] = function (block) {
+BlocklyPy['lego_boost_stop_motors'] = function (block) {
   var code = 'hub.motor_external.stop()\n';
   return code;
 };
 
-Blockly.Python['lego_boost_disconnect'] = function (block) {
+BlocklyPy['lego_boost_disconnect'] = function (block) {
   var code = 'hub.disconnect()\n';
   return code;
 };
 
-Blockly.Python['lego_boost_sleep'] = function (block) {
-  var value_seconds = Blockly.Python.valueToCode(
+BlocklyPy['lego_boost_sleep'] = function (block) {
+  var value_seconds = BlocklyPy.valueToCode(
     block,
     'SECONDS',
-    Blockly.Python.ORDER_ATOMIC
+    BlocklyPy.ORDER_ATOMIC
   );
 
   var code = 'time.sleep(' + value_seconds + ')\n';
+  return code;
 };
 
 Blockly.Blocks['lego_boost_sleep'].toplevel_init = `

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,10 +3827,10 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
-jupyterlab-blockly@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jupyterlab-blockly/-/jupyterlab-blockly-0.1.1.tgz#829738ed96f0da0032ea3733b48ce8deb2046a08"
-  integrity sha512-zU73Omvg86QzjtXlLZncR+W4sHfmDmL2pId8qeCZfkDczfIX6tlduJcw7eKyqa7eHWHox77VL8B5IrF99Uzp4w==
+jupyterlab-blockly@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/jupyterlab-blockly/-/jupyterlab-blockly-0.2.0.tgz#fc1467b832d7e981c1066890711063fc7adfa598"
+  integrity sha512-81btcNmyqzusDLWtAsiPKfQ+xmHQG4GX69r4M5N+nDe+12GJ1q7TKiLkqU5X5oC1/QwwUhewCfivOWoJMAtoZg==
   dependencies:
     "@jupyterlab/apputils" "^3.4"
     "@jupyterlab/cells" "^3.4"


### PR DESCRIPTION
Updated to newest version of `jupyterlab-blockly` and removed `sharedPackages` configuration, which was bringing the Python generator error for custom blocks.