### PR TITLE
Automated Changelog Entry for 0.0.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,25 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.1
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-lego-boost/compare/35d9882aef31adaad1d4ca9dcdfee9318db6dc24...06fa986076c1d498637b4aa0ad8b244bdd832181))
+
+### Enhancements made
+
+- Added MoveHub blocks [#2](https://github.com/QuantStack/jupyterlab-lego-boost/pull/2) ([@DenisaCG](https://github.com/DenisaCG))
+- Add Blockly to extension [#1](https://github.com/QuantStack/jupyterlab-lego-boost/pull/1) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Maintenance and upkeep improvements
+
+- Modified blocks structure [#5](https://github.com/QuantStack/jupyterlab-lego-boost/pull/5) ([@DenisaCG](https://github.com/DenisaCG))
+- Updated to `v0.2.1` of `jupyterlab-blockly` [#4](https://github.com/QuantStack/jupyterlab-lego-boost/pull/4) ([@DenisaCG](https://github.com/DenisaCG))
+- Updated to v0.2.0 of `jupyterlab-blockly`  [#3](https://github.com/QuantStack/jupyterlab-lego-boost/pull/3) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-lego-boost/graphs/contributors?from=2022-08-15&to=2022-09-23&type=c))
+
+[@DenisaCG](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-lego-boost+involves%3ADenisaCG+updated%3A2022-08-15..2022-09-23&type=Issues) | [@github-actions](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-lego-boost+involves%3Agithub-actions+updated%3A2022-08-15..2022-09-23&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.0.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/QuantStack/jupyterlab-lego-boost/releases/tag/untagged-22dfffbd5f67568616cb  |
