### PR TITLE
Automated Changelog Entry for 0.1.0a1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - Modified blocks structure [#5](https://github.com/QuantStack/jupyterlab-lego-boost/pull/5) ([@DenisaCG](https://github.com/DenisaCG))
 - Updated to `v0.2.1` of `jupyterlab-blockly` [#4](https://github.com/QuantStack/jupyterlab-lego-boost/pull/4) ([@DenisaCG](https://github.com/DenisaCG))
-- Updated to v0.2.0 of `jupyterlab-blockly`  [#3](https://github.com/QuantStack/jupyterlab-lego-boost/pull/3) ([@DenisaCG](https://github.com/DenisaCG))
+- Updated to v0.2.0 of `jupyterlab-blockly` [#3](https://github.com/QuantStack/jupyterlab-lego-boost/pull/3) ([@DenisaCG](https://github.com/DenisaCG))
 
 ### Documentation improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.1.0a0
+## 0.1.0a1
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-lego-boost/compare/35d9882aef31adaad1d4ca9dcdfee9318db6dc24...1b6b4d6e3f20876af9ad97d77c74d3d7823cb447))
+
+### Enhancements made
+
+- Added MoveHub blocks [#2](https://github.com/QuantStack/jupyterlab-lego-boost/pull/2) ([@DenisaCG](https://github.com/DenisaCG))
+- Add Blockly to extension [#1](https://github.com/QuantStack/jupyterlab-lego-boost/pull/1) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Maintenance and upkeep improvements
+
+- Modified blocks structure [#5](https://github.com/QuantStack/jupyterlab-lego-boost/pull/5) ([@DenisaCG](https://github.com/DenisaCG))
+- Updated to `v0.2.1` of `jupyterlab-blockly` [#4](https://github.com/QuantStack/jupyterlab-lego-boost/pull/4) ([@DenisaCG](https://github.com/DenisaCG))
+- Updated to v0.2.0 of `jupyterlab-blockly`  [#3](https://github.com/QuantStack/jupyterlab-lego-boost/pull/3) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Documentation improvements
+
+- Added instruction for connecting to the robot [#7](https://github.com/QuantStack/jupyterlab-lego-boost/pull/7) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-lego-boost/graphs/contributors?from=2022-08-15&to=2022-09-27&type=c))
+
+[@DenisaCG](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-lego-boost+involves%3ADenisaCG+updated%3A2022-08-15..2022-09-27&type=Issues) | [@github-actions](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-lego-boost+involves%3Agithub-actions+updated%3A2022-08-15..2022-09-27&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.1.0a0


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a1 on main
```
Python version: 0.1.0a1
npm version: jupyterlab-lego-boost: 0.1.0-alpha.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/QuantStack/jupyterlab-lego-boost/releases/tag/untagged-3ff3dacc672932bf8d58  |
| Since Last Stable | true |