### PR TITLE
Update repository links for new organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-lego-boost
 
-[![Github Actions Status](https://github.com/QuantStack/jupyterlab-lego-boost/workflows/Build/badge.svg)](https://github.com/QuantStack/jupyterlab-lego-boost/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/QuantStack/jupyterlab-lego-boost/main?urlpath=lab)
+[![Github Actions Status](https://github.com/jupyter-robotics/jupyterlab-lego-boost/workflows/Build/badge.svg)](https://github.com/jupyter-robotics/jupyterlab-lego-boost/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter-robotics/jupyterlab-lego-boost/main?urlpath=lab)
 Blockly extension for JupyterLab to control the Lego Boost
 
 ## Blockly

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "robot",
     "Boost"
   ],
-  "homepage": "https://github.com/QuantStack/jupyterlab-lego-boost",
+  "homepage": "https://github.com/jupyter-robotics/jupyterlab-lego-boost",
   "bugs": {
-    "url": "https://github.com/QuantStack/jupyterlab-lego-boost/issues"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-lego-boost/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
     "name": "Denisa Checiu",
-    "email": "me@test.com"
+    "email": "denisa.checiu@quantstack.net"
   },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
@@ -28,7 +28,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/QuantStack/jupyterlab-lego-boost.git"
+    "url": "https://github.com/jupyter-robotics/jupyterlab-lego-boost.git"
   },
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Update links in repository, since it has been moved from `QuantStack` to `jupyter-robotics`.